### PR TITLE
Level loading

### DIFF
--- a/Spectrum.pro
+++ b/Spectrum.pro
@@ -46,3 +46,6 @@ HEADERS  += \
 
 FORMS    += \
     ui/mainwindow.ui
+
+RESOURCES += \
+    levels/levels.qrc

--- a/include/level.h
+++ b/include/level.h
@@ -3,6 +3,7 @@
 
 #include <QtGlobal>
 #include <QGraphicsScene>
+#include <QFile>
 #include <QTextStream>
 #include <vector>
 #include "include/dynamicentity.h"
@@ -25,7 +26,7 @@ public:
     void applyGravity(qreal g);
 
 private:
-
+    void parse(QTextStream &fStream);
     void addStaticEntity(QTextStream &lineStream);
     void addDynamicEntity(QTextStream &lineStream);
 

--- a/include/level.h
+++ b/include/level.h
@@ -3,6 +3,7 @@
 
 #include <QtGlobal>
 #include <QGraphicsScene>
+#include <QTextStream>
 #include <vector>
 #include "include/dynamicentity.h"
 #include "include/block.h"
@@ -24,6 +25,10 @@ public:
     void applyGravity(qreal g);
 
 private:
+
+    void addStaticEntity(QTextStream &lineStream);
+    void addDynamicEntity(QTextStream &lineStream);
+
     std::vector<Entity *> _staticEntities;          // TODO can be const T*?
     std::vector<DynamicEntity *> _dynamicEntities;
     Player *_player;

--- a/include/level.h
+++ b/include/level.h
@@ -3,7 +3,6 @@
 
 #include <QtGlobal>
 #include <QGraphicsScene>
-#include <QFile>
 #include <QTextStream>
 #include <vector>
 #include "include/dynamicentity.h"
@@ -14,7 +13,7 @@
 
 class Level {
 public:
-    Level(Player *player);
+    Level(const QString &fileName, Player *player);
     ~Level();
 
     // TODO delete operator= and copy-constructor

--- a/include/level.h
+++ b/include/level.h
@@ -7,11 +7,12 @@
 #include "include/dynamicentity.h"
 #include "include/block.h"
 #include "include/cube.h"
+#include "include/player.h"
 
 
 class Level {
 public:
-    Level();
+    Level(Player *player);
     ~Level();
 
     // TODO delete operator= and copy-constructor
@@ -25,6 +26,7 @@ public:
 private:
     std::vector<Entity *> _staticEntities;          // TODO can be const T*?
     std::vector<DynamicEntity *> _dynamicEntities;
+    Player *_player;
 };
 
 #endif // LEVEL_H

--- a/levels/001.lvl
+++ b/levels/001.lvl
@@ -1,0 +1,14 @@
+# Player spawn coordinates
+p 200 180
+
+# Static entities
+s block 0 300 50 50
+s block 50 280 100 50
+s block 150 250 100 100
+s block 250 210 50 50
+s block 300 240 100 50
+s block 400 280 100 50
+s block 500 300 200 50
+
+# Dynamic entities
+d cube 20 20 50 50

--- a/levels/levels.qrc
+++ b/levels/levels.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/levels">
+        <file>001.lvl</file>
+    </qresource>
+</RCC>

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8,7 +8,7 @@ SpectrumGame::SpectrumGame(QGraphicsScene *scene) :
     _scene->addItem(_player);
 
     // Creating new level
-    _level = new Level();
+    _level = new Level(_player);
     _level->load(_scene);
 
     // Creating timer for gravity function

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8,7 +8,7 @@ SpectrumGame::SpectrumGame(QGraphicsScene *scene) :
     _scene->addItem(_player);
 
     // Creating new level
-    _level = new Level(_player);
+    _level = new Level(":levels/001.lvl", _player);
     _level->load(_scene);
 
     // Creating timer for gravity function

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -1,7 +1,4 @@
 #include "include/level.h"
-#include <QFile>
-#include <QTextStream>
-#include <QRegularExpression>
 
 
 Level::Level(Player *player) :
@@ -11,11 +8,17 @@ Level::Level(Player *player) :
     QFile f(":levels/001.lvl");
     if (f.open(QIODevice::ReadOnly) == false)
         exit(EXIT_FAILURE);
+
+    // Parse level file
     QTextStream fStream(&f);
+    parse(fStream);
 
-    // Spaces are used as separators in level file
-    QRegularExpression whiteSpaceRegex("\\s+");
+    // Close level file
+    f.close();
+}
 
+void Level::parse(QTextStream &fStream)
+{
     // Read level file line by line
     while (!fStream.atEnd()) {
         QString line = fStream.readLine().trimmed();
@@ -24,7 +27,7 @@ Level::Level(Player *player) :
         if (line.isEmpty() || line.startsWith("#"))
             continue;
 
-        // Read data from line
+        // Read data from the current line
         QTextStream lineStream(&line);
         char entityType;
         lineStream >> entityType;
@@ -46,7 +49,6 @@ Level::Level(Player *player) :
             break;
         }
     }
-    f.close();
 }
 
 void Level::addStaticEntity(QTextStream &lineStream)

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -30,22 +30,15 @@ Level::Level(Player *player) :
         lineStream >> entityType;
 
         // Determine which object to create
-        int x, y, w, h;
-        QString entityClass;
         switch (entityType) {
         case 's':   // Static
-            lineStream >> entityClass >> x >> y >> w >> h;
-            if (entityClass == "block")
-                _staticEntities.push_back(new Block(x, y, w, h));
-            // TODO Add here other static object types
+            addStaticEntity(lineStream);
             break;
         case 'd':   // Dynamic
-            lineStream >> entityClass >> x >> y >> w >> h;
-            if (entityClass == "cube")
-                _dynamicEntities.push_back(new Cube(x, y, w, h));
-            // TODO Add here other dynamic object types
+            addDynamicEntity(lineStream);
             break;
         case 'p':   // Player
+            int x, y;
             lineStream >> x >> y;
             _player->drawAt(x, y);
             break;
@@ -54,6 +47,28 @@ Level::Level(Player *player) :
         }
     }
     f.close();
+}
+
+void Level::addStaticEntity(QTextStream &lineStream)
+{
+    int x, y, w, h;
+    QString entityClass;
+    lineStream >> entityClass >> x >> y >> w >> h;
+
+    if (entityClass == "block")
+        _staticEntities.push_back(new Block(x, y, w, h));
+    // TODO Add here other static object types
+}
+
+void Level::addDynamicEntity(QTextStream &lineStream)
+{
+    int x, y, w, h;
+    QString entityClass;
+    lineStream >> entityClass >> x >> y >> w >> h;
+
+    if (entityClass == "cube")
+        _dynamicEntities.push_back(new Cube(x, y, w, h));
+    // TODO Add here other dynamic object types
 }
 
 Level::~Level()
@@ -85,6 +100,7 @@ void Level::applyGravity(qreal g)
     for (unsigned i = 0; i < _dynamicEntities.size(); i++)
         _dynamicEntities[i]->applyForce(0,g);
 }
+
 /*void Level::move(qreal g)
 {
     for (unsigned i = 0; i < _dynamicEntities.size(); i++)

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -1,13 +1,24 @@
 #include "include/level.h"
+#include <QMessageBox>
+#include <QFile>
+#include <QCoreApplication>
 
 
-Level::Level(Player *player) :
+Level::Level(const QString &fileName, Player *player) :
     _player(player)
 {
     // Open level file
-    QFile f(":levels/001.lvl");
-    if (f.open(QIODevice::ReadOnly) == false)
-        exit(EXIT_FAILURE);
+    QFile f(fileName);
+    if (f.open(QIODevice::ReadOnly) == false) {
+        QMessageBox::critical(nullptr, "Error",
+            "Loading level failed\nLoading default level...");
+        QFile fDef(":levels/001.lvl");
+        if (fDef.open(QIODevice::ReadOnly) == false) {
+            QMessageBox::critical(nullptr, "Error",
+                "Loading level failed\nLoading default level...");
+            QCoreApplication::exit(EXIT_FAILURE);
+        }
+    }
 
     // Parse level file
     QTextStream fStream(&f);


### PR DESCRIPTION
Basic level loading from the .lvl files.

Added levels/ in resources, and added a test file called 001.lvl

File format:
- \# for comments
- every line starts with p/s/d which correspond to player coordinates/static entity/dynamic entity respectively
- p has to be followed by two integers which determine (x,y) coordinates on the scene
- s and d have to be followed by four integers which determine xpos, ypos, width and height respectively
- if there are multiple lines that start with p, only the last one will be applied (they will all be applied but only the last one will be visible)
- the order of lines is not relevant, also it is not nececary to group lines that start with same character together